### PR TITLE
Fixing elapsed time issues

### DIFF
--- a/xdevs/models.py
+++ b/xdevs/models.py
@@ -256,6 +256,11 @@ class Atomic(Component, ABC):
         """
         self.deltint()
         self.deltext(0)
+        """
+        The other alternative would be this:
+            self.deltext(e)
+            self.deltint()
+        """
 
     def hold_in(self, phase: Any, sigma: Any):
         """

--- a/xdevs/models.py
+++ b/xdevs/models.py
@@ -259,7 +259,8 @@ class Atomic(Component, ABC):
         """
         The other alternative would be this:
             self.deltext(e)
-            self.deltint()
+            if self.ta == 0:
+                self.deltint()
         """
 
     def hold_in(self, phase: Any, sigma: Any):

--- a/xdevs/models.py
+++ b/xdevs/models.py
@@ -2,17 +2,20 @@ import inspect
 import pickle
 from abc import ABC, abstractmethod
 from collections import deque, defaultdict
-from typing import Any, Iterator, Tuple, List, Dict, Generator
+from typing import Any, Iterator, Tuple, List, Dict, Generator, Type, TypeVar, Generic
 
 from . import PHASE_ACTIVE, PHASE_PASSIVE, INFINITY
 
 
-class Port:
+T = TypeVar('T')
+
+
+class Port(Generic[T]):
 
     IN = "in"
     OUT = "out"
 
-    def __init__(self, p_type: type, name: str = None, serve: bool = False):
+    def __init__(self, p_type: Type[T], name: str = None, serve: bool = False):
         """
         xDEVS implementation of DEVS Port.
         :param p_type: data type of messages to be sent/received via the new port instance.
@@ -54,7 +57,7 @@ class Port:
         self._values.clear()
 
     @property
-    def values(self) -> Generator[Any, None, None]:
+    def values(self) -> Generator[T, None, None]:
         """:return: Generator function that returns all the messages in the port."""
         for val in self._values:
             yield val
@@ -63,14 +66,14 @@ class Port:
             for val in port._values:
                 yield val
 
-    def get(self) -> Any:
+    def get(self) -> T:
         """
         :return: first message from port.
         :raises StopIteration: if port is empty.
         """
         return next(self.values)
 
-    def add(self, val: Any):
+    def add(self, val: T):
         """
         Adds a new value to the local message bag of the port.
         :param val: message to be added.
@@ -80,7 +83,7 @@ class Port:
             raise TypeError("Value type is %s (%s expected)" % (type(val).__name__, self.p_type.__name__))
         self._values.append(val)
 
-    def extend(self, vals: Iterator[Any]):
+    def extend(self, vals: Iterator[T]):
         """
         Adds a set of new values to the local message bag of the port.
         :param vals: list containing all the messages to be added.
@@ -88,6 +91,7 @@ class Port:
         """
         for val in vals:
             self.add(val)
+
 
 class Component(ABC):
     def __init__(self, name: str = None):

--- a/xdevs/sim.py
+++ b/xdevs/sim.py
@@ -75,7 +75,6 @@ class Simulator(AbstractSimulator):
             self.model.deltint()
         else:
             e = t - self.time_last
-            self.model.sigma -= e
 
             if t == self.time_next:
                 self.model.deltcon(e)


### PR DESCRIPTION
Working on Mercury, I found strange situations where an internal simulation clock variable drifted when confluent transitions were triggered. After some time of debugging, I think that I found the issue:

When external events are received, the simulator automatically modifies the `sigma` variable of its model. Therefore, if the transition to be triggered is a confluent delta, `sigma` becomes 0. And if the confluent delta triggers first the internal delta (which is the default), the model will behave as if an internal delta with time advance 0 happened.

I propose to remove that line. In my opinion, `sigma` is part of the state, and cannot be modified by the simulator. If an external delta is activated with an elapsed time of `e`, the model has to deal with it and subtract `e` to `sigma` only when applies (for example, a model of a watchdog wouldn't modify `sigma`, and trigger an alert if an internal delta is activated).
 
Please, check my proposal so we are all sure that this change is necessary.